### PR TITLE
Add RenderFallback prop

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { FlagsProvider, withFeature, Feature, useFeature } from 'flagged';
+import { FlagsProvider, withFeature, Feature, useFeature } from '../../src/index';
 
 function VersionComponent({ version }) {
   return <h1>You are currently in {version}.</h1>;
@@ -50,9 +50,6 @@ function App() {
       <V1Component />
 
       <V2Component />
-
-      {/* Render Prop */}
-      <Feature name="v3" render={<V3Component />} />
 
       {/* Render and Render Fallback Prop */}
       <Feature name="v3" render={<V3Component />} renderFallback={<p>You are not in V3.</p>} />

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -54,6 +54,9 @@ function App() {
       {/* Render Prop */}
       <Feature name="v3" render={<V3Component />} />
 
+      {/* Render and Render Fallback Prop */}
+      <Feature name="v3" render={<V3Component />} renderFallback={<p>You are not in V3.</p>} />
+
       {/* Function as Children */}
       <Feature name="v4">
         {hasV4 => (hasV4 ? <V4Component /> : <h3>You are not in v4.</h3>)}

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { FlagsProvider, withFeature, Feature, useFeature } from '../../src/index';
+import { FlagsProvider, withFeature, Feature, useFeature } from 'flagged'; //#TODO: change to represent local version.
 
 function VersionComponent({ version }) {
   return <h1>You are currently in {version}.</h1>;
@@ -18,8 +18,9 @@ const V2Component = withFeature('v2')(function V2Component() {
   return <VersionComponent version="v2" />;
 });
 
-function V3Component() {
-  return <VersionComponent version="v3" />;
+function V3Component(props) {
+  const version = `v3 | from ${props.from}`;
+  return <VersionComponent version={version} />;
 }
 
 function V4Component() {
@@ -49,15 +50,32 @@ function App() {
 
       <V1Component />
 
-      <V2Component />
+      {/* Render Prop */}
+      <Feature name="v2" render={<V2Component />}/>
 
-      {/* Render and Render Fallback Prop */}
-      <Feature name="v3" render={<V3Component />} renderFallback={<p>You are not in V3.</p>} />
+      {/* Render Prop */}
+      <Feature name="v2" render={(isEnabled) =>
+          isEnabled ? <V2Component/> : <h3>You are not in V2</h3>
+      }/>
+
+
+      {/* Render and RenderFallback Prop */}
+      <Feature name="v3" render={<V3Component from="render prop"/>} renderFallback={<h3>You are not in V3| fallback from render prop.</h3>} />
+
+      {/* Children and RenderFallback Prop */}
+      <Feature name="v3" renderFallback={<h3>You are not in V3| fallback from children prop.</h3>}>
+        <V3Component from="children prop"/>
+      </Feature>
+
+      {/*Only Fallback Prop */}
+      <Feature name="v3" renderFallback={<h3>You are not in V3| only fallback.</h3>}>
+      </Feature>
 
       {/* Function as Children */}
       <Feature name="v4">
         {hasV4 => (hasV4 ? <V4Component /> : <h3>You are not in v4.</h3>)}
       </Feature>
+
     </FlagsProvider>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -77,7 +77,7 @@ export function Feature({
   const hasFeature = useFeature(name);
   if (!hasFeature && typeof renderFallback === 'function') return renderFallback();
   if (typeof render === 'function') return render(hasFeature);
-  if (!hasFeature) return null;
+  if (!hasFeature) return renderFallback;
   return render;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,6 +61,7 @@ export function Feature({
   name,
   children,
   render = children,
+  renderFallback = null
 }: {
   name: string;
   children?:
@@ -69,8 +70,12 @@ export function Feature({
   render?:
     | React.ReactNode
     | ((hasFeature: boolean | FeatureGroup) => JSX.Element);
+  renderFallback?:
+    | React.ReactNode
+    | (() => JSX.Element);
 }) {
   const hasFeature = useFeature(name);
+  if (!hasFeature && typeof renderFallback === 'function') return renderFallback();
   if (typeof render === 'function') return render(hasFeature);
   if (!hasFeature) return null;
   return render;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -78,7 +78,7 @@ export function Feature({
   if (!hasFeature && typeof renderFallback === 'function') return renderFallback();
   if (typeof render === 'function') return render(hasFeature);
   if (!hasFeature) return renderFallback;
-  return render;
+  return render ?? null;
 }
 
 // High Order Component API

--- a/test/hoc.test.tsx
+++ b/test/hoc.test.tsx
@@ -1,10 +1,9 @@
 import '@testing-library/jest-dom/extend-expect';
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Feature, FlagsProvider, withFeature } from '../src';
+import { FlagsProvider, withFeature } from '../src';
 
 const Tester = withFeature('featured')(() => <h1>It works</h1>);
-const Default = () => <h1>It works</h1>;
 
 describe(withFeature, () => {
   describe('array', () => {
@@ -44,28 +43,6 @@ describe(withFeature, () => {
       render(
         <FlagsProvider features={{ featured: false }}>
           <Tester />
-        </FlagsProvider>
-      );
-
-      expect(screen.queryByText(/It works/i)).not.toBeInTheDocument();
-    });
-  });
-
-  describe('fallback', () => {
-    test('exists', () => {
-      render(
-        <FlagsProvider features={{ featured: false }}>
-          <Feature name="featured" render={<React.Fragment/>} renderFallback={<Default/>}/>
-        </FlagsProvider>
-      );
-
-      expect(screen.queryByText(/It works/i)).toBeInTheDocument();
-    });
-
-    test("doesn't exists", () => {
-      render(
-        <FlagsProvider features={{ featured: true }}>
-          <Feature name="featured" render={<React.Fragment/>} renderFallback={<Default/>}/>
         </FlagsProvider>
       );
 

--- a/test/hoc.test.tsx
+++ b/test/hoc.test.tsx
@@ -1,9 +1,10 @@
 import '@testing-library/jest-dom/extend-expect';
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
-import { FlagsProvider, withFeature } from '../src';
+import { Feature, FlagsProvider, withFeature } from '../src';
 
 const Tester = withFeature('featured')(() => <h1>It works</h1>);
+const Default = () => <h1>It works</h1>;
 
 describe(withFeature, () => {
   describe('array', () => {
@@ -43,6 +44,28 @@ describe(withFeature, () => {
       render(
         <FlagsProvider features={{ featured: false }}>
           <Tester />
+        </FlagsProvider>
+      );
+
+      expect(screen.queryByText(/It works/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('fallback', () => {
+    test('exists', () => {
+      render(
+        <FlagsProvider features={{ featured: false }}>
+          <Feature name="featured" render={<React.Fragment/>} renderFallback={<Default/>}/>
+        </FlagsProvider>
+      );
+
+      expect(screen.queryByText(/It works/i)).toBeInTheDocument();
+    });
+
+    test("doesn't exists", () => {
+      render(
+        <FlagsProvider features={{ featured: true }}>
+          <Feature name="featured" render={<React.Fragment/>} renderFallback={<Default/>}/>
         </FlagsProvider>
       );
 

--- a/test/render-props.test.tsx
+++ b/test/render-props.test.tsx
@@ -100,6 +100,46 @@ describe(Feature, () => {
       expect(screen.queryByText(/It works/i)).not.toBeInTheDocument();
       expect(screen.queryByText(/It doesn't work/i)).toBeInTheDocument();
     });
+
+    test('renderFallback - element', () => {
+      render(
+        <FlagsProvider features={['featured']}>
+          <Feature name="random" render={<h1>It doesn't work</h1>} renderFallback={<h1>It works</h1>} />
+        </FlagsProvider>
+      );
+
+      expect(screen.queryByText(/It works/i)).toBeInTheDocument();
+    });
+
+    test('renderFallback - function - works', () => {
+      render(
+        <FlagsProvider features={['featured']}>
+          <Feature
+            name="random"
+            render={<h1>It does't work</h1>}
+            renderFallback={<h1>It works</h1>}
+          />
+        </FlagsProvider>
+      );
+
+      expect(screen.queryByText(/It doesn't work/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/It works/i)).toBeInTheDocument();
+    });
+
+    test("renderFallback - function - doesn't work", () => {
+      render(
+        <FlagsProvider features={['featured']}>
+          <Feature
+            name="featured"
+            render={<h1>It works</h1>}
+            renderFallback={<h1>It doesn't work</h1>}
+          />
+        </FlagsProvider>
+      );
+
+      expect(screen.queryByText(/It works/i)).toBeInTheDocument();
+      expect(screen.queryByText(/It doesn't work/i)).not.toBeInTheDocument();
+    });
   });
 
   describe('object', () => {
@@ -185,6 +225,46 @@ describe(Feature, () => {
 
       expect(screen.queryByText(/It works/i)).not.toBeInTheDocument();
       expect(screen.queryByText(/It doesn't work/i)).toBeInTheDocument();
+    });
+
+    test('renderFallback - element', () => {
+      render(
+        <FlagsProvider features={{ featured: true }}>
+          <Feature name="random" render={<h1>It doesn't work</h1>} renderFallback={<h1>It works</h1>} />
+        </FlagsProvider>
+      );
+
+      expect(screen.queryByText(/It works/i)).toBeInTheDocument();
+    });
+
+    test('renderFallback - function - works', () => {
+      render(
+        <FlagsProvider features={{ featured: true }}>
+          <Feature
+            name="random"
+            render={<h1>It does't work</h1>}
+            renderFallback={<h1>It works</h1>}
+          />
+        </FlagsProvider>
+      );
+
+      expect(screen.queryByText(/It doesn't work/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/It works/i)).toBeInTheDocument();
+    });
+
+    test("renderFallback - function - doesn't work", () => {
+      render(
+        <FlagsProvider features={{ featured: true }}>
+          <Feature
+            name="featured"
+            render={<h1>It works</h1>}
+            renderFallback={<h1>It doesn't work</h1>}
+          />
+        </FlagsProvider>
+      );
+
+      expect(screen.queryByText(/It works/i)).toBeInTheDocument();
+      expect(screen.queryByText(/It doesn't work/i)).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Adds a function to execute when the feature is not enabled.

### E.g: 
 
#### Renders `You are not in V3| fallback from render prop` when the feature is disabled and a render template is defined
 ```jsx
{/* Render and RenderFallback Prop */}
<Feature name="v3" render={<V3Component/>} 
    renderFallback={<h3>You are not in V3| fallback from render prop.</h3>} />
```
#### Renders `You are not in V3| fallback from children prop` when the feature is disabled and a children template is defined
```jsx
  {/* Children and RenderFallback Prop */}
  <Feature name="v3" renderFallback={<h3>You are not in V3| fallback from children prop.</h3>}>
    <V3Component/>
  </Feature>
```

#### Renders `You are not in V3| only fallback` when the feature is disabled without any render function or children defined
```jsx
  {/*Only Fallback Prop */}
  <Feature name="v3" renderFallback={<h3>You are not in V3| only fallback.</h3>}>
  </Feature>
```

Test: https://codesandbox.io/s/silly-river-eo4sn?file=/src/App.js:86-101
![image](https://user-images.githubusercontent.com/40893204/135311366-a75a1912-131a-45d3-8e93-47eeb42d4d4a.png)
